### PR TITLE
Cannot use plugin in multiple filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vagrant/
 Vagrantfile
 test.sh
+.gitconfig

--- a/README.md
+++ b/README.md
@@ -19,12 +19,15 @@ gem install fluent-plugin-json-transform
   format json_transform
   transform_script [nothing|flatten|custom]
   script_path "/home/grayson/transform_script.rb" # ignored if transform_script != custom
+  class_name "CustomJSONTransformer" # [optional] default value is "JSONTransformer", ignored if transform_script != custom
 </source>
 ```
 
 `transform_script`: `nothing` to do nothing, `flatten` to flatten JSON by concatenating nested keys (see below), or `custom` 
 
-`script_path`: ignored if not using `custom` script. Point this to a Ruby script which implements the `JSONTransformer` class.
+`script_path`: ignored if not using `custom` script. Point this to a Ruby script which implements the [`class_name` | `JSONTransformer`] class.
+
+`class_name`: [optional] ignored if not using `custom` script. Define name of a class which is used for transformation in `script_path` script.
 
 ###Flatten script
 Flattens nested JSON by concatenating nested keys with '.'. Example:
@@ -54,23 +57,24 @@ Becomes
 ```
 
 ###New Filter Option
-Filtering is now supported, if you want to flatten your json after doing other parsing from the original source log.
+If you want to flatten your json after doing other parsing from the original source log.
 ```
 <filter pattern>
   @type json_transform
   transform_script [nothing|flatten|custom]
   script_path "/home/grayson/transform_script.rb" # ignored if transform_script != custom
+  class_name "CustomJSONTransformer" # [optional] default value is "JSONTransformer", ignored if transform_script != custom
 </filter>
 ```
 
 
-##Implementing JSONTransformer
+##Implementing transformer class
 
-The `JSONTransformer` class should have an instance method `transform` which takes a Ruby hash and returns a Ruby hash:
+The transformer class should have an instance method `transform` which takes a Ruby hash and returns a Ruby hash. Pay attention that the name of a class should be the same as you defined in `class_name` parameter or `JSONTransformer` in case `class_name` parameter is not defined:
 
 ```ruby
 # lib/transform/flatten.rb
-class JSONTransformer
+class JSONTransformer # or any class name defined in class_name parameter
   def transform(json)
     return flatten(json, "")
   end

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # JSON Transform parser plugin for Fluentd
 
-##Overview
+## Overview
 This is a [parser plugin](http://docs.fluentd.org/articles/parser-plugin-overview) for fluentd. It is **INCOMPATIBLE WITH FLUENTD v0.10.45 AND BELOW.**
 
 
 It was created for the purpose of modifying [**good.js**](https://github.com/hapijs/good) logs
 before storing them in Elasticsearch. It may not be useful for any other purpose, but be creative.
 
-##Installation
+## Installation
 ```bash
 gem install fluent-plugin-json-transform
 ```
 
-##Configuration
+## Configuration
 ```
 <source>
   type [tail|tcp|udp|syslog|http] # or a custom input type which accepts the "format" parameter
@@ -25,11 +25,11 @@ gem install fluent-plugin-json-transform
 
 `transform_script`: `nothing` to do nothing, `flatten` to flatten JSON by concatenating nested keys (see below), or `custom` 
 
-`script_path`: ignored if not using `custom` script. Point this to a Ruby script which implements the [`class_name` | `JSONTransformer`] class.
+`script_path`: ignored if not using `custom` script. Point this to a Ruby script which implements the class from `class_name` parameter.
 
 `class_name`: [optional] ignored if not using `custom` script. Define name of a class which is used for transformation in `script_path` script.
 
-###Flatten script
+### Flatten script
 Flattens nested JSON by concatenating nested keys with '.'. Example:
 
 ```
@@ -56,7 +56,7 @@ Becomes
 }
 ```
 
-###New Filter Option
+### Filter Option
 If you want to flatten your json after doing other parsing from the original source log.
 ```
 <filter pattern>
@@ -68,7 +68,7 @@ If you want to flatten your json after doing other parsing from the original sou
 ```
 
 
-##Implementing transformer class
+## Implementing transformer class
 
 The transformer class should have an instance method `transform` which takes a Ruby hash and returns a Ruby hash. Pay attention that the name of a class should be the same as you defined in `class_name` parameter or `JSONTransformer` in case `class_name` parameter is not defined:
 

--- a/lib/fluent/plugin/filter_json_transform.rb
+++ b/lib/fluent/plugin/filter_json_transform.rb
@@ -3,27 +3,34 @@ module Fluent
     Fluent::Plugin.register_filter('json_transform', self)
 
     DEFAULTS = [ 'nothing', 'flatten' ]
+    DEFAULT_CLASS_NAME = 'JSONTransformer'
 
     include Configurable
     config_param :transform_script, :string
     config_param :script_path, :string
+    config_param :class_name, :string
 
     def configure(conf)
       @transform_script = conf['transform_script']
 
       if DEFAULTS.include?(@transform_script)
         @transform_script = "#{__dir__}/../../transform/#{@transform_script}.rb"
+        className = DEFAULT_CLASS_NAME
       elsif @transform_script == 'custom'
         @transform_script = conf['script_path']
+        className = conf['class_name'] || DEFAULT_CLASS_NAME
       end
 
       require @transform_script
-      @transformer = JSONTransformer.new
+      begin
+        @transformer = Object.const_get(className).new
+      rescue NameError
+        @transformer = Object.const_get(DEFAULT_CLASS_NAME).new
+      end
     end
 
     def filter(tag, time, record)
-      flattened = @transformer.transform(record)
-      return flattened
+      return @transformer.transform(record)
     end
   end
 end

--- a/lib/fluent/plugin/parser_json_transform.rb
+++ b/lib/fluent/plugin/parser_json_transform.rb
@@ -2,23 +2,30 @@ module Fluent
   class TextParser
     class JSONTransformParser
       DEFAULTS = [ 'nothing', 'flatten' ]
+      DEFAULT_CLASS_NAME = 'JSONTransformer'
 
       include Configurable
       config_param :transform_script, :string
       config_param :script_path, :string
+      config_param :class_name, :string
 
       def configure(conf)
         @transform_script = conf['transform_script']
 
         if DEFAULTS.include?(@transform_script)
-          @transform_script =
-            "#{__dir__}/../../transform/#{@transform_script}.rb"
+          @transform_script = "#{__dir__}/../../transform/#{@transform_script}.rb"
+          className = DEFAULT_CLASS_NAME
         elsif @transform_script == 'custom'
           @transform_script = conf['script_path']
+          className = conf['class_name'] || DEFAULT_CLASS_NAME
         end
 
         require @transform_script
-        @transformer = JSONTransformer.new
+        begin
+          @transformer = Object.const_get(className).new
+        rescue NameError
+          @transformer = Object.const_get(DEFAULT_CLASS_NAME).new
+        end
       end
 
       def call(text)


### PR DESCRIPTION
This issue happens when you try to use this plugin in a multiple filters using different scripts defined in _script_path_ parameter. One of them always fails. The problem is that both scripts are used in parallel with different filters but both scripts has a class with the same name.